### PR TITLE
add explicit unknown context type to heterogeneous converters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fgv/ts-utils",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Assorted Typescript Utilities",
   "main": "dist/index.js",
   "scripts": {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -173,11 +173,11 @@ export const optionalBoolean = boolean.optional();
  * @param converters An ordered list of converters to be considered
  * @param onError Specifies treatment of unconvertable elements
  */
-export function oneOf<T>(converters: Array<Converter<T, unknown>>, onError: OnError = 'ignoreErrors'): Converter<T, unknown> {
-    return new BaseConverter((from: unknown) => {
+export function oneOf<T, TC=unknown>(converters: Array<Converter<T, TC>>, onError: OnError = 'ignoreErrors'): Converter<T, TC> {
+    return new BaseConverter((from: unknown, _self, context?: TC) => {
         const errors: string[] = [];
         for (const converter of converters) {
-            const result = converter.convert(from);
+            const result = converter.convert(from, context);
             if (result.isSuccess() && (result.value !== undefined)) {
                 return result;
             }
@@ -355,14 +355,14 @@ export function optionalField<T, TC=undefined>(name: string, converter: Converte
     });
 }
 
-export type FieldConverters<T> = { [ key in keyof T ]: Converter<T[key], unknown> };
+export type FieldConverters<T, TC=unknown> = { [ key in keyof T ]: Converter<T[key], TC> };
 
-export class ObjectConverter<T> extends BaseConverter<T, unknown> {
+export class ObjectConverter<T, TC=unknown> extends BaseConverter<T, TC> {
     public readonly fields: FieldConverters<T>;
     public readonly optionalFields: (keyof T)[];
 
-    public constructor(fields: FieldConverters<T>, optional?: (keyof T)[]) {
-        super((from: unknown) => {
+    public constructor(fields: FieldConverters<T, TC>, optional?: (keyof T)[]) {
+        super((from: unknown, _self, context?: TC) => {
             // eslint bug thinks key is used before defined
             // eslint-disable-next-line no-use-before-define
             const converted = {} as { [key in keyof T]: T[key] };
@@ -371,8 +371,8 @@ export class ObjectConverter<T> extends BaseConverter<T, unknown> {
                 if (fields[key]) {
                     const isOptional = optional?.includes(key) ?? false;
                     const result = isOptional
-                        ? optionalField(key, fields[key]).convert(from)
-                        : field(key, fields[key]).convert(from);
+                        ? optionalField(key, fields[key]).convert(from, context)
+                        : field(key, fields[key]).convert(from, context);
                     if (result.isSuccess() && (result.value !== undefined)) {
                         converted[key] = result.value;
                     }
@@ -388,11 +388,11 @@ export class ObjectConverter<T> extends BaseConverter<T, unknown> {
         this.optionalFields = optional ?? [];
     }
 
-    public partial(optional?: (keyof T)[]): ObjectConverter<Partial<T>> {
-        return new ObjectConverter<Partial<T>>(this.fields as FieldConverters<Partial<T>>, optional);
+    public partial(optional?: (keyof T)[]): ObjectConverter<Partial<T>, TC> {
+        return new ObjectConverter<Partial<T>, TC>(this.fields as FieldConverters<Partial<T>, TC>, optional);
     }
 
-    public addPartial(addOptionalFields: (keyof T)[]): ObjectConverter<Partial<T>> {
+    public addPartial(addOptionalFields: (keyof T)[]): ObjectConverter<Partial<T>, TC> {
         return this.partial([...this.optionalFields, ...addOptionalFields]);
     }
 }
@@ -427,8 +427,8 @@ export function object<T>(fields: FieldConverters<T>, optional?: (keyof T)[]): O
  * @param fields An object defining the shape of the target object and the field converters
  * to be used to construct it.
  */
-export function transform<T>(fields: FieldConverters<T>): Converter<T, unknown> {
-    return new BaseConverter((from: unknown) => {
+export function transform<T, TC=unknown>(fields: FieldConverters<T, TC>): Converter<T, TC> {
+    return new BaseConverter((from: unknown, _self, context?: TC) => {
         // eslint bug thinks key is used before defined
         // eslint-disable-next-line no-use-before-define
         const converted = {} as { [ key in keyof T]: T[key] };
@@ -436,7 +436,7 @@ export function transform<T>(fields: FieldConverters<T>): Converter<T, unknown> 
 
         for (const key in fields) {
             if (fields[key]) {
-                const result = fields[key].convert(from);
+                const result = fields[key].convert(from, context);
                 if (result.isSuccess() && (result.value !== undefined)) {
                     converted[key] = result.value;
                 }
@@ -455,12 +455,12 @@ export function transform<T>(fields: FieldConverters<T>): Converter<T, unknown> 
  * @param converter Converter used to convert min and max extent of the raid
  * @param constructor Optional static constructor to instantiate the object
  */
-export function rangeTypeOf<T, RT extends RangeOf<T>>(converter: Converter<T>, constructor: (init: RangeOfProperties<T>) => Result<RT>): Converter<RT, unknown> {
-    return new BaseConverter((from: unknown) => {
+export function rangeTypeOf<T, RT extends RangeOf<T>, TC=unknown>(converter: Converter<T, TC>, constructor: (init: RangeOfProperties<T>) => Result<RT>): Converter<RT, TC> {
+    return new BaseConverter((from: unknown, _self, context?: TC) => {
         const result = object({
             min: converter,
             max: converter,
-        }, ['min', 'max']).convert(from);
+        }, ['min', 'max']).convert(from, context);
         if (result.isSuccess()) {
             return constructor({ min: result.value.min, max: result.value.max });
         }
@@ -468,6 +468,6 @@ export function rangeTypeOf<T, RT extends RangeOf<T>>(converter: Converter<T>, c
     });
 }
 
-export function rangeOf<T>(converter: Converter<T>): Converter<RangeOf<T>> {
-    return rangeTypeOf<T, RangeOf<T>>(converter, RangeOf.createRange);
+export function rangeOf<T, TC=unknown>(converter: Converter<T, TC>): Converter<RangeOf<T>, TC> {
+    return rangeTypeOf<T, RangeOf<T>, TC>(converter, RangeOf.createRange);
 }

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -173,7 +173,7 @@ export const optionalBoolean = boolean.optional();
  * @param converters An ordered list of converters to be considered
  * @param onError Specifies treatment of unconvertable elements
  */
-export function oneOf<T>(converters: Array<Converter<T>>, onError: OnError = 'ignoreErrors'): Converter<T> {
+export function oneOf<T>(converters: Array<Converter<T, unknown>>, onError: OnError = 'ignoreErrors'): Converter<T, unknown> {
     return new BaseConverter((from: unknown) => {
         const errors: string[] = [];
         for (const converter of converters) {
@@ -355,9 +355,9 @@ export function optionalField<T, TC=undefined>(name: string, converter: Converte
     });
 }
 
-export type FieldConverters<T> = { [ key in keyof T ]: Converter<T[key]> };
+export type FieldConverters<T> = { [ key in keyof T ]: Converter<T[key], unknown> };
 
-export class ObjectConverter<T> extends BaseConverter<T> {
+export class ObjectConverter<T> extends BaseConverter<T, unknown> {
     public readonly fields: FieldConverters<T>;
     public readonly optionalFields: (keyof T)[];
 
@@ -427,7 +427,7 @@ export function object<T>(fields: FieldConverters<T>, optional?: (keyof T)[]): O
  * @param fields An object defining the shape of the target object and the field converters
  * to be used to construct it.
  */
-export function transform<T>(fields: FieldConverters<T>): Converter<T> {
+export function transform<T>(fields: FieldConverters<T>): Converter<T, unknown> {
     return new BaseConverter((from: unknown) => {
         // eslint bug thinks key is used before defined
         // eslint-disable-next-line no-use-before-define
@@ -455,7 +455,7 @@ export function transform<T>(fields: FieldConverters<T>): Converter<T> {
  * @param converter Converter used to convert min and max extent of the raid
  * @param constructor Optional static constructor to instantiate the object
  */
-export function rangeTypeOf<T, RT extends RangeOf<T>>(converter: Converter<T>, constructor: (init: RangeOfProperties<T>) => Result<RT>): Converter<RT> {
+export function rangeTypeOf<T, RT extends RangeOf<T>>(converter: Converter<T>, constructor: (init: RangeOfProperties<T>) => Result<RT>): Converter<RT, unknown> {
     return new BaseConverter((from: unknown) => {
         const result = object({
             min: converter,

--- a/test/unit/converters.test.ts
+++ b/test/unit/converters.test.ts
@@ -200,6 +200,15 @@ describe('Converters module', () => {
                 });
             });
 
+            test('can combine converters with different context types', () => {
+                type TestEnum = 'enum1'|'enum2';
+                const enumConverter = Converters.enumeratedValue<TestEnum>(['enum1', 'enum2']);
+                const enumFirst = Converters.oneOf<TestEnum|number>([enumConverter, Converters.number]);
+                expect(enumFirst.convert('enum1')).toSucceedWith('enum1');
+                expect(enumFirst.convert(123)).toSucceedWith(123);
+                expect(enumFirst.convert('enum7')).toFailWith(/invalid enumerated value/i);
+            });
+
             test('fails if none of the converters can handle the value', () => {
                 expect(numFirst.convert(true)).toFailWith(/no matching converter/i);
             });
@@ -720,6 +729,7 @@ describe('Converters module', () => {
         interface Want {
             stringField: string;
             optionalStringField?: string;
+            enumField: 'enum1'|'enum2',
             numField: number;
             boolField: boolean;
             numbers?: number[];
@@ -728,6 +738,7 @@ describe('Converters module', () => {
         const converter = Converters.object<Want>({
             stringField: Converters.string,
             optionalStringField: Converters.string,
+            enumField: Converters.enumeratedValue<'enum1'|'enum2'>(['enum1', 'enum2']),
             numField: Converters.number,
             boolField: Converters.boolean,
             numbers: Converters.arrayOf(Converters.number),
@@ -739,12 +750,14 @@ describe('Converters module', () => {
         test('converts a valid object with missing optional fields', () => {
             const src = {
                 stringField: 'string1',
+                enumField: 'enum1',
                 numField: -1,
                 boolField: true,
             };
 
             const expected: Want = {
                 stringField: 'string1',
+                enumField: 'enum1',
                 numField: -1,
                 boolField: true,
             };
@@ -757,6 +770,7 @@ describe('Converters module', () => {
             const src = {
                 stringField: 'string1',
                 optionalStringField: 'optional string',
+                enumField: 'enum2',
                 numField: -1,
                 boolField: true,
                 numbers: [-1, 0, 1, '2'],
@@ -765,6 +779,7 @@ describe('Converters module', () => {
             const expected: Want = {
                 stringField: 'string1',
                 optionalStringField: 'optional string',
+                enumField: 'enum2',
                 numField: -1,
                 boolField: true,
                 numbers: [-1, 0, 1, 2],
@@ -799,6 +814,7 @@ describe('Converters module', () => {
             const partialConverter = Converters.object<Want>({
                 stringField: Converters.string,
                 optionalStringField: Converters.optionalString,
+                enumField: Converters.enumeratedValue<'enum1'|'enum2'>(['enum1', 'enum2']),
                 numField: Converters.number,
                 boolField: Converters.boolean,
                 numbers: undefined,
@@ -807,6 +823,7 @@ describe('Converters module', () => {
             const src = {
                 stringField: 'string1',
                 optionalStringField: 'optional string',
+                enumField: 'enum1',
                 numField: -1,
                 boolField: true,
                 numbers: [-1, 0, 1, '2'],
@@ -815,6 +832,7 @@ describe('Converters module', () => {
             const expected: Want = {
                 stringField: 'string1',
                 optionalStringField: 'optional string',
+                enumField: 'enum1',
                 numField: -1,
                 boolField: true,
             };
@@ -827,6 +845,7 @@ describe('Converters module', () => {
             test('succeeds if any of the added fields are missing', () => {
                 const src = {
                     numField: -1,
+                    enumField: 'enum1',
                     boolField: true,
                 };
 


### PR DESCRIPTION
Add explicit unknown context type to heterogeneous converters (object and oneOf) so they can be used with child converters that accept some other context

fixes #28